### PR TITLE
Harden kubernetes configurations

### DIFF
--- a/templates/etcd-config.yaml.tmpl
+++ b/templates/etcd-config.yaml.tmpl
@@ -1,6 +1,6 @@
 name: "${peername}"
 data-dir: /var/lib/etcd
-listen-client-urls: https://0.0.0.0:2379
+listen-client-urls: ${listen_client_urls}
 advertise-client-urls: ${advertise_client_url}
 listen-peer-urls: ${listen_peer_url}
 initial-advertise-peer-urls: ${initial_advertise_peer_url}

--- a/templates/kube-apiserver.service.tmpl
+++ b/templates/kube-apiserver.service.tmpl
@@ -4,7 +4,7 @@ After=network.target etcd.service
 
 [Service]
 ExecStart=/usr/local/bin/kube-apiserver \
-  --advertise-address=0.0.0.0 \
+  --advertise-address=${advertise_address} \
   --allow-privileged=true \
   --authorization-mode=Node,RBAC \
   --client-ca-file=/etc/kubernetes/pki/ca.crt \

--- a/templates/kubelet-config.yaml.tmpl
+++ b/templates/kubelet-config.yaml.tmpl
@@ -10,3 +10,9 @@ tlsPrivateKeyFile: "/var/lib/kubelet/pki/kubelet.key"
 authentication:
   x509:
     clientCAFile: "/var/lib/kubernetes/pki/client-ca.crt"
+  anonymous:
+    enabled: false
+  webhook:
+    enabled: true
+authorization:
+  mode: Webhook


### PR DESCRIPTION
## Summary
- update API server to advertise a specific address
- restrict etcd client listener to specific addresses
- disable anonymous kubelet auth and use Webhook authorization
- adjust certificate organizations for controller manager and etcd clients

## Testing
- `terraform fmt -check && terraform validate` *(fails: terraform not installed)*