### PR TITLE
Update etcd to 3.6.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ cluster_service_cidr = "10.96.0.0/12"
 cluster_dns_ip       = "10.96.0.10"
 cluster_dns_domain   = "cluster.local"
 
-etcd_version          = "v3.5.16"
+etcd_version          = "v3.6.1"
 kubernetes_version    = "v1.32.0"
 cni_plugins_version   = "v1.5.0"
 coredns_version       = "1.9.4"

--- a/variables.tf
+++ b/variables.tf
@@ -18,7 +18,7 @@ variable "ssh_private_key_path" {
 
 variable "etcd_version" {
   type    = string
-  default = "v3.5.16"
+  default = "v3.6.1"
 }
 
 variable "kubernetes_version" {


### PR DESCRIPTION
## Summary
- bump etcd version to v3.6.1 in docs and defaults

## Testing
- `terraform fmt -check` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685425a7827483329e710a209e8f3263